### PR TITLE
Add reference-verification subsystem and CLI subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This tool combines the features of [doi2bib](https://github.com/bibcure/doi2bib/
   and DOI content negotiation with Crossref fallback.
 - Normalizes BibTeX output, including journal abbreviation mappings and
   selected publisher-specific cleanup.
+- **Verifies** existing BibTeX references against CrossRef, arXiv, and the DOI
+  Handle System to catch hallucinated or mistyped citations -- see
+  [Verifying references](#verifying-references).
 - Full pipeline documentation (input -> output): [`docs/ALGORITHM.md`](docs/ALGORITHM.md)
 - Diagram version of the pipeline: [`docs/ALGORITHM_VISUALS.md`](docs/ALGORITHM_VISUALS.md)
 
@@ -62,18 +65,22 @@ pip install -e .
 
 ## CLI usage
 
-The CLI accepts a single positional identifier and an optional `-o/--out`
-path to save the BibTeX output. When installed, the package installs a console
-script named `doi2bib3` (configured in `pyproject.toml`). From the repository
-root you can run the local script wrapper at `scripts/doi2bib3`.
+The CLI has two subcommands -- `fetch` (the historical behaviour) and
+`verify` (described below). When installed, the package installs a console
+script named `doi2bib3`. From the repository root you can also run the
+local wrapper at `scripts/doi2bib3`.
 
 ```bash
-# using the local wrapper script from repo root
-python scripts/doi2bib3 <identifier> [-o OUT]
+# Fetch BibTeX for a single identifier
+doi2bib3 fetch <identifier> [-o OUT]
 
-# or when installed as console script
-doi2bib3 <identifier> -o references.bib
+# Verify the references in a .bib file or project folder
+doi2bib3 verify <path> [--json]
 ```
+
+For backward compatibility, `doi2bib3 <identifier>` with no subcommand is
+treated as `doi2bib3 fetch <identifier>`, so every example below continues
+to work unchanged.
 
 ## Examples
 
@@ -119,6 +126,56 @@ doi2bib3 https://doi.org/10.1038/nphys1170 -o paper.bib
 
 Note: If the tool is not installed, you can run `python scripts/doi2bib3 https://doi.org/10.1038/nphys1170`.
 
+## Verifying references
+
+Large language models often invent realistic-looking citations -- DOIs that
+do not resolve, papers that were never written, or DOIs that point to a
+completely different article. `doi2bib3 verify` checks every BibTeX entry
+against authoritative databases (CrossRef, arXiv, the DOI registry) and
+tells you which ones hold up.
+
+Verification is **deterministic**: the real record for each entry is fetched
+and the title, authors and year are corroborated in code -- no AI service,
+API key, or subscription is involved. Each reference is reported as one of:
+
+- **verified** -- an identifier resolves and the metadata is corroborated, or
+  the title and authors were matched in CrossRef.
+- **review** -- the work exists, but its registered metadata could not be
+  matched to the entry with confidence; worth a quick look.
+- **mismatch** -- the DOI/arXiv ID resolves, but to a record with a different
+  title *and* different authors.
+- **unresolved** -- the DOI/arXiv ID does not resolve in CrossRef or the DOI
+  registry.
+- **unverified** -- the entry had no identifier and no confident match, or a
+  database was unreachable.
+
+```bash
+doi2bib3 verify references.bib
+doi2bib3 verify ./paper-folder            # walks .bib + .tex files
+doi2bib3 verify references.bib --json     # machine-readable output
+```
+
+When `.tex` files are present alongside `.bib` files, the tool also reports
+`\cite` keys that are not defined in any `.bib` file (a common sign of an
+invented citation key).
+
+### Programmatic verification
+
+```python
+from doi2bib3 import verify_bibtex, summary
+
+results = verify_bibtex(open("references.bib").read())
+print(summary(results))           # counts by status
+
+for r in results:
+    if r.needs_attention:
+        print(r.key, r.status, r.reason)
+```
+
+Lower-level entry points are available too: `parse_bibtex` to split parsing
+from verification, `verify_entry` / `verify_entries` for finer control, and
+`check_cite_keys` / `extract_cite_keys` for the LaTeX-side cite-key check.
+
 ## Supported journal groups
 
 `doi2bib3` directly supports many APS, AMS, ACS, Nature, PNAS, SciPost, ScienceDirect and IOP groups of journals.
@@ -128,9 +185,15 @@ For other journals, the DOI link works, but the paper's URL would not work..
 
 ### Public API
 
-The Python API exposes one primary function:
+The Python API exposes:
 
 - `doi2bib3.fetch_bibtex(identifier: str, timeout: int = 15) -> str`
+- `doi2bib3.verify_bibtex(text: str, *, timeout: int = 20) -> list[VerificationResult]`
+- `doi2bib3.parse_bibtex(text: str) -> list[BibEntry]`
+- `doi2bib3.verify_entry(entry, *, timeout: int = 20) -> VerificationResult`
+- `doi2bib3.verify_entries(entries, *, timeout: int = 20, max_workers: int = 4, progress=None) -> list[VerificationResult]`
+- `doi2bib3.summary(results) -> dict[str, int]`
+- `doi2bib3.check_cite_keys(tex_sources, defined_keys) -> CiteCheckResult`
 
 Example:
 
@@ -151,7 +214,10 @@ for automated CLI tests.
 - `doi2bib3/backend.py`: input resolution and network fetch logic
 - `doi2bib3/normalize.py`: BibTeX normalization/transforms
 - `doi2bib3/io.py`: file output helpers
-- `scripts/doi2bib3`: command-line argument parsing and output handling
+- `doi2bib3/cli.py`: argparse-based CLI with `fetch` and `verify` subcommands
+- `doi2bib3/verify/`: deterministic reference verification engine
+  (parser, matching, CrossRef/arXiv/DOI-handle lookups, verdict logic)
+- `scripts/doi2bib3`: legacy script wrapper that forwards to `doi2bib3.cli`
 
 ## License
 

--- a/doi2bib3/__init__.py
+++ b/doi2bib3/__init__.py
@@ -1,5 +1,46 @@
 """doi2bib3 package shim."""
 
 from .backend import fetch_bibtex
+from .verify import (
+    BibEntry,
+    CiteCheckResult,
+    ERROR,
+    MISMATCH,
+    NOT_FOUND,
+    REVIEW,
+    STATUS_ICON,
+    UNVERIFIED,
+    VERIFIED,
+    VerificationResult,
+    check_cite_keys,
+    extract_cite_keys,
+    normalize_doi,
+    parse_bibtex,
+    summary,
+    verify_bibtex,
+    verify_entries,
+    verify_entry,
+)
 
-__all__ = ["fetch_bibtex"]
+__all__ = [
+    "fetch_bibtex",
+    # Verify engine
+    "BibEntry",
+    "parse_bibtex",
+    "normalize_doi",
+    "CiteCheckResult",
+    "check_cite_keys",
+    "extract_cite_keys",
+    "VerificationResult",
+    "verify_entry",
+    "verify_entries",
+    "verify_bibtex",
+    "summary",
+    "VERIFIED",
+    "REVIEW",
+    "MISMATCH",
+    "NOT_FOUND",
+    "UNVERIFIED",
+    "ERROR",
+    "STATUS_ICON",
+]

--- a/doi2bib3/cli.py
+++ b/doi2bib3/cli.py
@@ -1,0 +1,276 @@
+"""Command-line interface for ``doi2bib3``.
+
+Two subcommands:
+
+* ``doi2bib3 fetch <identifier> [-o FILE]`` -- the historical behaviour:
+  resolve a DOI / arXiv id / URL / title and emit the BibTeX.
+* ``doi2bib3 verify <path> [--json]`` -- check a ``.bib`` file (or a folder
+  that contains ``.bib`` / ``.tex`` files) against authoritative databases
+  and report unverifiable, mismatched or unresolved references.
+
+For backward compatibility, ``doi2bib3 <identifier>`` (with no recognised
+subcommand) is treated as ``doi2bib3 fetch <identifier>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .backend import fetch_bibtex
+from .io import save_bibtex_to_file
+from .verify import (
+    STATUS_ICON,
+    VERIFIED,
+    check_cite_keys,
+    parse_bibtex,
+    summary,
+    verify_entries,
+)
+
+_SUBCOMMANDS = ("fetch", "verify")
+_HELP_FLAGS = ("-h", "--help", "help", "-V", "--version")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the doi2bib3 CLI.
+
+    Returns a process exit code:
+    ``0`` on success, ``1`` on a runtime/network error, ``2`` when verify
+    surfaces references that need attention or undefined cite keys.
+    """
+    # Keep output crash-free when a reference title contains characters the
+    # console encoding cannot represent (common on Windows code pages).
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(errors="replace")
+        except (AttributeError, ValueError):
+            pass
+
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    # Legacy form: ``doi2bib3 10.1038/...`` (no subcommand) -> treat as ``fetch``.
+    if argv and argv[0] not in _SUBCOMMANDS and argv[0] not in _HELP_FLAGS:
+        argv = ["fetch", *argv]
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "fetch":
+        return _cmd_fetch(args)
+    if args.command == "verify":
+        return _cmd_verify(args)
+    parser.print_help()
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="doi2bib3",
+        description=(
+            "Fetch BibTeX from a DOI/arXiv id/URL/title, "
+            "or verify references against CrossRef/arXiv."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_fetch = sub.add_parser(
+        "fetch",
+        help="Fetch BibTeX for a single identifier (DOI, arXiv id, URL, title).",
+        description=(
+            "Resolve an identifier to a DOI and emit the normalized BibTeX entry."
+        ),
+    )
+    p_fetch.add_argument(
+        "identifier",
+        nargs="?",
+        help="DOI, DOI URL, arXiv id/URL, publisher URL, or article title.",
+    )
+    p_fetch.add_argument("-o", "--out", help="Write .bib file to this path (append).")
+
+    p_verify = sub.add_parser(
+        "verify",
+        help="Verify BibTeX references against authoritative databases.",
+        description=(
+            "Check every entry in a .bib file (or folder of .bib/.tex files) "
+            "against CrossRef, arXiv and the DOI registry."
+        ),
+    )
+    p_verify.add_argument(
+        "source",
+        nargs="?",
+        help="Path to a .bib file or a folder containing .bib/.tex files.",
+    )
+    p_verify.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Concurrent lookups (default: 4).",
+    )
+    p_verify.add_argument(
+        "--timeout",
+        type=int,
+        default=20,
+        help="Per-request timeout in seconds.",
+    )
+    p_verify.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of a text report.",
+    )
+
+    return parser
+
+
+# --------------------------------------------------------------------------
+# fetch
+# --------------------------------------------------------------------------
+
+def _cmd_fetch(args) -> int:
+    if not args.identifier:
+        print(
+            "doi2bib3 fetch: provide a DOI, arXiv id, URL, or article title.",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        bib = fetch_bibtex(args.identifier)
+    except Exception as exc:  # noqa: BLE001 - surface any backend error
+        print("Error:", exc, file=sys.stderr)
+        return 1
+
+    if args.out:
+        save_bibtex_to_file(bib, args.out, append=True)
+        print("Wrote", args.out)
+    else:
+        print(bib)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# verify
+# --------------------------------------------------------------------------
+
+def _cmd_verify(args) -> int:
+    if not args.source:
+        print(
+            "doi2bib3 verify: provide a .bib file or a folder.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        entries, tex_sources, label = _collect(Path(args.source))
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not entries:
+        print(f"No BibTeX entries found in {label}.", file=sys.stderr)
+        return 1
+
+    show_progress = not args.json
+    results = verify_entries(
+        entries,
+        timeout=args.timeout,
+        max_workers=args.workers,
+        progress=_progress if show_progress else None,
+    )
+    if show_progress:
+        print("", file=sys.stderr)
+
+    cite = None
+    if tex_sources:
+        cite = check_cite_keys(tex_sources, {e.key for e in entries if e.key})
+
+    if args.json:
+        _print_json(label, results, cite)
+    else:
+        _print_report(label, results, cite)
+
+    flagged = any(r.needs_attention for r in results)
+    bad_keys = bool(cite and cite.undefined)
+    return 1 if (flagged or bad_keys) else 0
+
+
+def _collect(path: Path) -> tuple[list, list[str], str]:
+    """Read a .bib file, a .tex file, or a folder containing both."""
+    entries: list = []
+    tex_sources: list[str] = []
+
+    if not path.exists():
+        raise OSError(f"No such file or folder: {path}")
+
+    if path.is_dir():
+        for bib in sorted(path.rglob("*.bib")):
+            entries += parse_bibtex(_read(bib))
+        tex_sources = [_read(t) for t in sorted(path.rglob("*.tex"))]
+        return entries, tex_sources, str(path)
+
+    text = _read(path)
+    if path.suffix.lower() == ".tex":
+        tex_sources.append(text)
+    else:
+        entries = parse_bibtex(text)
+    return entries, tex_sources, str(path)
+
+
+def _read(path: Path) -> str:
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def _progress(done: int, total: int) -> None:
+    print(f"\rVerifying references... {done}/{total}", end="", file=sys.stderr)
+
+
+def _print_report(label: str, results: list, cite) -> None:
+    counts = summary(results)
+    print("doi2bib3 reference verifier")
+    print(f"Source: {label}")
+    print(
+        f"Checked {counts['total']} references - "
+        f"{counts['verified']} verified, {counts['review']} review, "
+        f"{counts['mismatch']} mismatch, {counts['not_found']} unresolved, "
+        f"{counts['unverified'] + counts['error']} unverified"
+    )
+    print()
+
+    flagged = [r for r in results if r.status != VERIFIED]
+    if not flagged:
+        print("  [OK] All references verified against CrossRef / arXiv.")
+    for r in flagged:
+        print(f"  [{STATUS_ICON.get(r.status, r.status)}] {r.key}")
+        if r.title:
+            print(f"      title : {r.title}")
+        print(f"      {r.reason}")
+        for issue in r.issues:
+            print(f"      - {issue}")
+        print()
+
+    if cite is not None:
+        print(f"Cite-key check: {len(cite.cited)} cited, {len(cite.defined)} defined")
+        if cite.undefined:
+            print(
+                "  Cited but NOT defined in any .bib (possibly invented keys): "
+                + ", ".join(sorted(cite.undefined))
+            )
+        if cite.unused:
+            print("  Defined but never cited: " + ", ".join(sorted(cite.unused)))
+        if not cite.undefined and not cite.unused:
+            print("  [OK] Every cited key is defined.")
+
+
+def _print_json(label: str, results: list, cite) -> None:
+    payload = {
+        "source": label,
+        "summary": summary(results),
+        "results": [r.to_dict() for r in results],
+    }
+    if cite is not None:
+        payload["citeCheck"] = cite.to_dict()
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doi2bib3/verify/__init__.py
+++ b/doi2bib3/verify/__init__.py
@@ -1,0 +1,49 @@
+"""Reference-verification engine for doi2bib3.
+
+A deterministic toolkit that decides whether the BibTeX references in a
+paper are *authentic* or likely *hallucinated*. Each entry is checked
+against authoritative databases (CrossRef, arXiv, the DOI Handle System)
+and the verdict is produced purely by code -- no AI service is involved.
+
+The most common entry points are :func:`verify_bibtex`, :func:`verify_entries`
+and :func:`verify_entry`. ``BibEntry`` / :func:`parse_bibtex` let callers
+split parsing from verification when they need fine-grained control.
+"""
+
+from .bibparser import BibEntry, normalize_doi, parse_bibtex
+from .citecheck import CiteCheckResult, check_cite_keys, extract_cite_keys
+from .verifier import (
+    ERROR,
+    MISMATCH,
+    NOT_FOUND,
+    REVIEW,
+    STATUS_ICON,
+    UNVERIFIED,
+    VERIFIED,
+    VerificationResult,
+    summary,
+    verify_bibtex,
+    verify_entries,
+    verify_entry,
+)
+
+__all__ = [
+    "BibEntry",
+    "parse_bibtex",
+    "normalize_doi",
+    "CiteCheckResult",
+    "check_cite_keys",
+    "extract_cite_keys",
+    "VerificationResult",
+    "verify_entry",
+    "verify_entries",
+    "verify_bibtex",
+    "summary",
+    "VERIFIED",
+    "REVIEW",
+    "MISMATCH",
+    "NOT_FOUND",
+    "UNVERIFIED",
+    "ERROR",
+    "STATUS_ICON",
+]

--- a/doi2bib3/verify/bibparser.py
+++ b/doi2bib3/verify/bibparser.py
@@ -1,0 +1,251 @@
+"""A small, dependency-free BibTeX (.bib) parser.
+
+It is deliberately lenient: real-world ``.bib`` files contain all kinds of
+quirks, and for reference verification we only need the citation key plus a
+handful of fields (title, author, year, doi, eprint). Anything it cannot
+parse is skipped rather than raising.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from .matching import clean
+
+# arXiv identifiers: new style (1501.00001) and old style (hep-th/9901001).
+_ARXIV_NEW = re.compile(r"\b(\d{4}\.\d{4,5})(v\d+)?\b")
+_ARXIV_OLD = re.compile(r"\b([a-z][a-z\-]+(?:\.[A-Z]{2})?/\d{7})(v\d+)?\b")
+_DOI_IN_TEXT = re.compile(r"10\.\d{4,9}/[^\s{}\"<>]+", re.IGNORECASE)
+
+
+@dataclass
+class BibEntry:
+    """A single parsed BibTeX entry (``@article{key, ...}``)."""
+
+    entry_type: str
+    key: str
+    fields: dict[str, str] = field(default_factory=dict)
+    line: int = 0
+
+    def get(self, name: str) -> str:
+        """Case-insensitive field lookup; returns ``""`` when absent."""
+        return self.fields.get(name.lower(), "")
+
+    @property
+    def title(self) -> str:
+        return clean(self.get("title"))
+
+    @property
+    def year(self) -> str:
+        for name in ("year", "date"):
+            m = re.search(r"\d{4}", self.get(name))
+            if m:
+                return m.group(0)
+        return ""
+
+    @property
+    def authors(self) -> list[str]:
+        """Author surnames-and-names split on the BibTeX ``and`` separator."""
+        raw = self.get("author") or self.get("editor")
+        if not raw:
+            return []
+        raw = clean(raw)
+        return [a.strip() for a in re.split(r"\s+and\s+", raw) if a.strip()]
+
+    @property
+    def doi(self) -> str:
+        """Normalized DOI from the ``doi`` field, or extracted from a URL."""
+        doi = self.get("doi")
+        if not doi:
+            for name in ("url", "note", "howpublished"):
+                m = _DOI_IN_TEXT.search(self.get(name))
+                if m:
+                    doi = m.group(0)
+                    break
+        return normalize_doi(doi)
+
+    @property
+    def arxiv_id(self) -> str:
+        """arXiv identifier from ``eprint``/``archiveprefix`` or a URL/journal."""
+        prefix = self.get("archiveprefix").lower() or self.get("eprinttype").lower()
+        eprint = self.get("eprint").strip()
+        if eprint and ("arxiv" in prefix or not prefix):
+            cand = re.sub(r"(?i)^arxiv:", "", eprint).strip()
+            if _ARXIV_NEW.search(cand) or _ARXIV_OLD.search(cand):
+                return cand
+        for name in ("journal", "url", "note", "eprint"):
+            text = self.get(name)
+            if "arxiv" in text.lower():
+                m = _ARXIV_NEW.search(text) or _ARXIV_OLD.search(text)
+                if m:
+                    return m.group(0)
+        return ""
+
+
+def normalize_doi(doi: str) -> str:
+    """Strip URL/`doi:` prefixes and surrounding noise; lowercase the result."""
+    if not doi:
+        return ""
+    doi = doi.strip().strip("{}").strip()
+    doi = re.sub(r"(?i)^\s*(https?://)?(dx\.)?doi\.org/", "", doi)
+    doi = re.sub(r"(?i)^\s*doi:\s*", "", doi)
+    return doi.strip().rstrip(".").lower()
+
+
+def parse_bibtex(text: str) -> list[BibEntry]:
+    """Parse BibTeX source into a list of :class:`BibEntry`.
+
+    ``@string`` definitions are collected and substituted; ``@comment`` and
+    ``@preamble`` blocks are ignored.
+    """
+    strings: dict[str, str] = {}
+    entries: list[BibEntry] = []
+    i, n = 0, len(text)
+
+    while i < n:
+        at = text.find("@", i)
+        if at == -1:
+            break
+        j = at + 1
+        while j < n and (text[j].isalnum() or text[j] in "_-"):
+            j += 1
+        etype = text[at + 1:j].strip().lower()
+        while j < n and text[j] in " \t\r\n":
+            j += 1
+        if j >= n or text[j] not in "{(":
+            i = at + 1
+            continue
+
+        opener = text[j]
+        body, end = _read_block(text, j, opener)
+        line = text.count("\n", 0, at) + 1
+        i = end
+
+        if etype in ("comment", "preamble") or not etype:
+            continue
+        if etype == "string":
+            name, value = _parse_string_def(body, strings)
+            if name:
+                strings[name.lower()] = value
+            continue
+
+        key, fields = _parse_entry_body(body, strings)
+        if key or fields:
+            entries.append(BibEntry(etype, key, fields, line))
+
+    return entries
+
+
+def _read_block(text: str, open_idx: int, opener: str) -> tuple[str, int]:
+    """Return (inner-body, index-after-close) for a brace/paren delimited block."""
+    closer = "}" if opener == "{" else ")"
+    depth = 1
+    k = open_idx + 1
+    n = len(text)
+    while k < n and depth > 0:
+        c = text[k]
+        if c == "\\":
+            k += 2
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0 and opener == "{":
+                return text[open_idx + 1:k], k + 1
+        elif c == closer and opener == "(" and depth == 1:
+            return text[open_idx + 1:k], k + 1
+        k += 1
+    return text[open_idx + 1:k], k
+
+
+def _split_top_level(body: str, sep: str) -> list[str]:
+    """Split on ``sep`` only where it is outside braces and quotes."""
+    parts: list[str] = []
+    depth = 0
+    in_quote = False
+    start = 0
+    i = 0
+    while i < len(body):
+        c = body[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == '"' and depth == 0:
+            in_quote = not in_quote
+        elif not in_quote:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth = max(0, depth - 1)
+            elif c == sep and depth == 0:
+                parts.append(body[start:i])
+                start = i + 1
+        i += 1
+    parts.append(body[start:])
+    return parts
+
+
+def _parse_entry_body(body: str, strings: dict[str, str]) -> tuple[str, dict[str, str]]:
+    """Split an entry body into its citation key and field dictionary."""
+    chunks = _split_top_level(body, ",")
+    key = chunks[0].strip() if chunks else ""
+    fields: dict[str, str] = {}
+    for chunk in chunks[1:]:
+        if "=" not in chunk:
+            continue
+        eq = _first_equals(chunk)
+        if eq < 0:
+            continue
+        name = chunk[:eq].strip().lower()
+        if name:
+            fields[name] = _parse_value(chunk[eq + 1:], strings)
+    return key, fields
+
+
+def _first_equals(chunk: str) -> int:
+    """Index of the first ``=`` outside braces/quotes, or -1."""
+    depth = 0
+    in_quote = False
+    i = 0
+    while i < len(chunk):
+        c = chunk[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == '"' and depth == 0:
+            in_quote = not in_quote
+        elif not in_quote:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth = max(0, depth - 1)
+            elif c == "=" and depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _parse_value(raw: str, strings: dict[str, str]) -> str:
+    """Parse a (possibly ``#``-concatenated) field value into a plain string."""
+    out: list[str] = []
+    for token in _split_top_level(raw, "#"):
+        token = token.strip()
+        if not token:
+            continue
+        if token[0] == "{" or token[0] == '"':
+            out.append(token[1:-1] if len(token) >= 2 else token)
+        elif token.lower() in strings:
+            out.append(strings[token.lower()])
+        else:
+            out.append(token)
+    return re.sub(r"\s+", " ", "".join(out)).strip()
+
+
+def _parse_string_def(body: str, strings: dict[str, str]) -> tuple[str, str]:
+    """Parse the body of an ``@string{ name = "value" }`` definition."""
+    eq = _first_equals(body)
+    if eq < 0:
+        return "", ""
+    return body[:eq].strip(), _parse_value(body[eq + 1:], strings)

--- a/doi2bib3/verify/citecheck.py
+++ b/doi2bib3/verify/citecheck.py
@@ -1,0 +1,64 @@
+"""Cross-check ``\\cite`` keys in LaTeX against the keys defined in BibTeX.
+
+This catches a distinct class of hallucination that needs no network access:
+a citation command that points at a key which was never defined in any
+``.bib`` file (an invented citation key), and -- as a bonus -- entries that
+are defined but never cited.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Matches the whole \cite family: \cite, \citep, \citet, \autocite,
+# \textcite, \parencite, \footcite, \nocite, \citeauthor, ... including a
+# trailing ``*`` and up to two optional ``[...]`` arguments.
+_CITE_RE = re.compile(
+    r"\\[a-zA-Z]*cite[a-zA-Z]*\*?\s*(?:\[[^\]]*\]\s*){0,2}\{([^}]+)\}"
+)
+_COMMENT_RE = re.compile(r"(?<!\\)%.*")
+
+
+@dataclass
+class CiteCheckResult:
+    """Outcome of comparing cited keys against defined keys."""
+
+    cited: set[str] = field(default_factory=set)
+    defined: set[str] = field(default_factory=set)
+    undefined: set[str] = field(default_factory=set)  # cited but never defined
+    unused: set[str] = field(default_factory=set)     # defined but never cited
+
+    def to_dict(self) -> dict:
+        return {
+            "citedCount": len(self.cited),
+            "definedCount": len(self.defined),
+            "undefined": sorted(self.undefined),
+            "unused": sorted(self.unused),
+        }
+
+
+def extract_cite_keys(tex: str) -> set[str]:
+    """Return every citation key referenced by ``\\cite``-style commands."""
+    keys: set[str] = set()
+    for stripped in (_COMMENT_RE.sub("", line) for line in tex.splitlines()):
+        for match in _CITE_RE.finditer(stripped):
+            for key in match.group(1).split(","):
+                key = key.strip()
+                if key:
+                    keys.add(key)
+    return keys
+
+
+def check_cite_keys(tex_sources: list[str], defined_keys: set[str]) -> CiteCheckResult:
+    """Compare keys cited across LaTeX sources with keys defined in BibTeX."""
+    cited: set[str] = set()
+    for tex in tex_sources:
+        cited |= extract_cite_keys(tex)
+    defined = set(defined_keys)
+    return CiteCheckResult(
+        cited=cited,
+        defined=defined,
+        undefined=cited - defined,
+        unused=defined - cited,
+    )

--- a/doi2bib3/verify/matching.py
+++ b/doi2bib3/verify/matching.py
@@ -1,0 +1,137 @@
+"""Text normalization and fuzzy similarity helpers for reference verification.
+
+These functions are deterministic and dependency-free. They are used to
+compare the metadata written in a BibTeX entry against the authoritative
+record returned by CrossRef / arXiv, so the verifier can decide whether the
+two describe the same publication.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from difflib import SequenceMatcher
+
+# A few LaTeX accent / escaped characters that commonly appear inside titles.
+_ESCAPED = {
+    r"\&": "&",
+    r"\%": "%",
+    r"\_": "_",
+    r"\$": "$",
+    r"\#": "#",
+    r"\{": "{",
+    r"\}": "}",
+}
+
+
+def strip_markup(text: str) -> str:
+    """Remove LaTeX *and* XML/HTML markup so only plain words remain.
+
+    CrossRef routinely returns titles with embedded JATS / MathML / HTML tags
+    (``<mml:math>``, ``<jats:sub>`` ...). Together with LaTeX control sequences
+    in BibTeX, that markup must be stripped before two titles can be compared.
+    Tags are removed (their text content kept), entities are decoded, LaTeX
+    control sequences are dropped, and braces are unwrapped.
+    """
+    if not text:
+        return ""
+    text = html.unescape(text)
+    # Strip XML/HTML/JATS/MathML tags, keeping the text between them.
+    text = re.sub(r"<[^>]+>", "", text)
+    for src, dst in _ESCAPED.items():
+        text = text.replace(src, dst)
+    # Drop control sequences but leave the following text/argument in place.
+    text = re.sub(r"\\[a-zA-Z]+\*?\s*", " ", text)
+    text = text.replace("{", "").replace("}", "")
+    text = text.replace("\\", " ")
+    return text
+
+
+# Backwards-compatible alias.
+strip_latex = strip_markup
+
+
+def clean(text: str) -> str:
+    """Human-readable cleanup: strip LaTeX/XML markup and collapse whitespace."""
+    return re.sub(r"\s+", " ", strip_markup(text or "")).strip()
+
+
+def normalize(text: str) -> str:
+    """Aggressive normalization for comparison.
+
+    Lowercased, LaTeX stripped, reduced to ``a-z0-9`` words. Two strings that
+    normalize to the same value describe, for our purposes, the same thing.
+    """
+    if not text:
+        return ""
+    text = strip_markup(text).lower()
+    text = re.sub(r"[^a-z0-9 ]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def contained(a: str, b: str) -> bool:
+    """True when the shorter of two normalized titles sits inside the longer.
+
+    Lets a main title match "main title: subtitle" (CrossRef often stores a
+    book's main title without its subtitle). The shorter side must be a real
+    title (>= 4 words), not a stray fragment, to avoid spurious matches.
+    """
+    short, long = sorted((a, b), key=len)
+    if len(short.split()) < 4:
+        return False
+    return short in long
+
+
+def similarity(a: str, b: str) -> float:
+    """Return a 0.0-1.0 similarity score between two free-text strings.
+
+    Designed to recognise the *same* publication despite encoding differences
+    between sources (LaTeX vs MathML maths, missing subtitles, re-ordered
+    words). Combines: a containment check (subtitles), a whitespace-insensitive
+    character ratio (maths/markup encoding), a plain character ratio, and a
+    word-set Jaccard score (re-ordering).
+    """
+    na, nb = normalize(a), normalize(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    if contained(na, nb):
+        return 0.95
+    # Whitespace-insensitive: "$ABC$" and "<mml:mi>A</mml:mi>B<...>C" both
+    # collapse to "abc", so tokenisation differences stop mattering.
+    squashed = SequenceMatcher(
+        None, na.replace(" ", ""), nb.replace(" ", "")
+    ).ratio()
+    seq = SequenceMatcher(None, na, nb).ratio()
+    ta, tb = set(na.split()), set(nb.split())
+    jaccard = len(ta & tb) / len(ta | tb) if (ta | tb) else 0.0
+    word_blend = 0.4 * seq + 0.6 * jaccard
+    return round(max(squashed, word_blend), 4)
+
+
+def author_overlap(bib_authors: list[str], record_authors: list[str]) -> float:
+    """Fraction of record authors whose surname appears in the BibTeX entry."""
+    if not bib_authors or not record_authors:
+        return 0.0
+    bib_surnames = {_surname(a) for a in bib_authors if _surname(a)}
+    if not bib_surnames:
+        return 0.0
+    hits = sum(1 for a in record_authors if _surname(a) in bib_surnames)
+    return round(hits / len(record_authors), 4)
+
+
+def _surname(author: str) -> str:
+    """Extract a normalized surname from a BibTeX/plain author string.
+
+    Handles both BibTeX name forms: ``Surname, Given`` and ``Given Surname``.
+    """
+    author = (author or "").strip()
+    if not author:
+        return ""
+    if "," in author:
+        surname = author.split(",", 1)[0]
+    else:
+        parts = author.split()
+        surname = parts[-1] if parts else ""
+    return normalize(surname)

--- a/doi2bib3/verify/sources.py
+++ b/doi2bib3/verify/sources.py
@@ -1,0 +1,218 @@
+"""Authoritative-record lookups against CrossRef, arXiv and the DOI registry.
+
+This is the part that makes verification *deterministic*: a BibTeX entry is
+checked against what these public services actually return, not against any
+model's opinion. No API key is required.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.parse
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+import requests
+
+from ..constants import USER_AGENT
+from .matching import clean
+
+CROSSREF_API = "https://api.crossref.org/works"
+ARXIV_API = "http://export.arxiv.org/api/query"
+DOI_HANDLE_API = "https://doi.org/api/handles/"
+
+_ATOM = {"a": "http://www.w3.org/2005/Atom"}
+_MAX_RETRIES = 3
+
+_session = requests.Session()
+_session.headers.update({"User-Agent": USER_AGENT})
+
+
+class SourceError(Exception):
+    """Raised when a service could not be reached or returned bad data."""
+
+
+@dataclass
+class Record:
+    """A normalized publication record from an authoritative database."""
+
+    title: str = ""
+    authors: list[str] = field(default_factory=list)
+    year: str = ""
+    doi: str = ""
+    container: str = ""
+    source: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.title or self.doi)
+
+
+def _http_get(url: str, *, timeout: int, accept: str, _attempt: int = 0) -> bytes:
+    """Perform a GET request, translating HTTP/network failure into SourceError.
+
+    Returns ``b""`` for a clean 404 so callers can treat "not found" as data.
+    Transient throttling (429) and outages (503) are retried with backoff.
+    """
+    host = urllib.parse.urlsplit(url).netloc
+    try:
+        resp = _session.get(url, headers={"Accept": accept}, timeout=timeout)
+    except requests.exceptions.RequestException as exc:
+        if _attempt < _MAX_RETRIES:
+            time.sleep(_retry_delay(None, _attempt))
+            return _http_get(url, timeout=timeout, accept=accept, _attempt=_attempt + 1)
+        raise SourceError(f"Could not reach {host}: {exc}")
+
+    if resp.status_code == 200:
+        return resp.content
+    if resp.status_code == 404:
+        return b""
+    if resp.status_code in (429, 503) and _attempt < _MAX_RETRIES:
+        retry_after = resp.headers.get("Retry-After")
+        time.sleep(_retry_delay(retry_after, _attempt))
+        return _http_get(url, timeout=timeout, accept=accept, _attempt=_attempt + 1)
+    raise SourceError(f"HTTP {resp.status_code} from {host}")
+
+
+def _retry_delay(retry_after: str | None, attempt: int) -> float:
+    """Seconds to wait before a retry: honour Retry-After, else backoff."""
+    if retry_after:
+        try:
+            return min(float(retry_after), 30.0)
+        except ValueError:
+            pass
+    return float(2 ** (attempt + 1))  # 2s, 4s, 8s
+
+
+# --------------------------------------------------------------------------
+# DOI registry (Handle System)
+# --------------------------------------------------------------------------
+
+def doi_exists(doi: str, *, timeout: int = 20) -> bool | None:
+    """Report whether a DOI is registered with *any* agency.
+
+    Uses the DOI Handle System, which - unlike CrossRef - also covers DataCite,
+    book and dataset DOIs. Returns ``True`` (registered), ``False`` (does not
+    exist), or ``None`` (could not be checked).
+    """
+    if not doi:
+        return None
+    url = f"{DOI_HANDLE_API}{urllib.parse.quote(doi, safe='')}"
+    try:
+        body = _http_get(url, timeout=timeout, accept="application/json")
+    except SourceError:
+        return None
+    if not body:  # the Handle API returns 404 for an unknown handle
+        return False
+    try:
+        code = json.loads(body).get("responseCode")
+    except ValueError:
+        return None
+    # 1 = success, 200 = handle exists but no values; 100 = handle not found.
+    return code != 100
+
+
+# --------------------------------------------------------------------------
+# CrossRef
+# --------------------------------------------------------------------------
+
+def crossref_by_doi(doi: str, *, timeout: int = 20) -> Record | None:
+    """Look up a DOI in CrossRef. Returns ``None`` if CrossRef has no such work."""
+    if not doi:
+        return None
+    url = f"{CROSSREF_API}/{urllib.parse.quote(doi, safe='')}"
+    body = _http_get(url, timeout=timeout, accept="application/json")
+    if not body:
+        return None
+    try:
+        message = json.loads(body)["message"]
+    except (ValueError, KeyError) as exc:
+        raise SourceError(f"Unexpected CrossRef response: {exc}")
+    return _record_from_crossref(message)
+
+
+def crossref_search(
+    title: str, author: str | None = None, *, rows: int = 5, timeout: int = 20
+) -> list[Record]:
+    """Search CrossRef by bibliographic title (and optionally first author)."""
+    if not title:
+        return []
+    params = {"query.bibliographic": title, "rows": str(rows)}
+    if author:
+        params["query.author"] = author
+    url = f"{CROSSREF_API}?{urllib.parse.urlencode(params)}"
+    body = _http_get(url, timeout=timeout, accept="application/json")
+    if not body:
+        return []
+    try:
+        items = json.loads(body)["message"]["items"]
+    except (ValueError, KeyError) as exc:
+        raise SourceError(f"Unexpected CrossRef response: {exc}")
+    return [_record_from_crossref(it) for it in items]
+
+
+def _record_from_crossref(message: dict) -> Record:
+    title_list = message.get("title") or [""]
+    container = message.get("container-title") or [""]
+    authors = []
+    for a in message.get("author", []) or []:
+        family = (a.get("family") or "").strip()
+        given = (a.get("given") or "").strip()
+        name = f"{family}, {given}".strip(", ") or (a.get("name") or "").strip()
+        if name:
+            authors.append(name)
+    year = ""
+    for key in ("published", "published-print", "published-online", "issued"):
+        parts = (message.get(key) or {}).get("date-parts") or [[]]
+        if parts and parts[0] and parts[0][0]:
+            year = str(parts[0][0])
+            break
+    return Record(
+        title=clean(title_list[0] or ""),
+        authors=authors,
+        year=year,
+        doi=(message.get("DOI") or "").lower(),
+        container=clean(container[0] or ""),
+        source="CrossRef",
+    )
+
+
+# --------------------------------------------------------------------------
+# arXiv
+# --------------------------------------------------------------------------
+
+def arxiv_lookup(arxiv_id: str, *, timeout: int = 20) -> Record | None:
+    """Look up an arXiv identifier. Returns ``None`` if it does not exist."""
+    if not arxiv_id:
+        return None
+    url = f"{ARXIV_API}?{urllib.parse.urlencode({'id_list': arxiv_id.strip(), 'max_results': 1})}"
+    body = _http_get(url, timeout=timeout, accept="application/atom+xml")
+    if not body:
+        return None
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as exc:
+        raise SourceError(f"Unexpected arXiv response: {exc}")
+    entry = root.find("a:entry", _ATOM)
+    if entry is None:
+        return None
+    entry_id = entry.findtext("a:id", default="", namespaces=_ATOM) or ""
+    title = (entry.findtext("a:title", default="", namespaces=_ATOM) or "").strip()
+    # arXiv returns a placeholder "Error" entry for identifiers that do not exist.
+    if "api/errors" in entry_id or title.lower() == "error":
+        return None
+    authors = []
+    for a in entry.findall("a:author", _ATOM):
+        name = (a.findtext("a:name", default="", namespaces=_ATOM) or "").strip()
+        if name:
+            authors.append(name)
+    published = entry.findtext("a:published", default="", namespaces=_ATOM) or ""
+    doi = (entry.findtext("{http://arxiv.org/schemas/atom}doi", default="") or "").lower()
+    return Record(
+        title=clean(title),
+        authors=authors,
+        year=published[:4],
+        doi=doi,
+        container="arXiv",
+        source="arXiv",
+    )

--- a/doi2bib3/verify/verifier.py
+++ b/doi2bib3/verify/verifier.py
@@ -1,0 +1,351 @@
+"""The verification engine: decide whether a BibTeX entry is authentic.
+
+A verdict is reached purely by code, from corroborating evidence:
+
+* whether the DOI / arXiv identifier resolves at all (CrossRef, and the
+  registry-agnostic DOI Handle System);
+* how well the registered title matches the entry's title;
+* whether the authors and year corroborate.
+
+A reference is only ``verified`` when authoritative data backs it up, and a
+hard verdict (``not_found`` / ``mismatch``) is only reached when two
+independent signals agree. Anything uncertain is surfaced as ``review`` or
+``unverified`` rather than guessed at.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Callable
+
+from .bibparser import BibEntry, parse_bibtex
+from .matching import author_overlap, similarity
+from .sources import (
+    Record,
+    SourceError,
+    arxiv_lookup,
+    crossref_by_doi,
+    crossref_search,
+    doi_exists,
+)
+
+# Verdict values.
+VERIFIED = "verified"      # corroborated against an authoritative record
+REVIEW = "review"          # the work exists, but metadata could not be confirmed
+MISMATCH = "mismatch"      # identifier resolves, but to a clearly different paper
+NOT_FOUND = "not_found"    # the identifier does not resolve anywhere
+UNVERIFIED = "unverified"  # could not be checked (no identifiers, no match, offline)
+ERROR = "error"            # unexpected failure
+
+# Decision thresholds.
+_TITLE_STRONG = 0.80
+_TITLE_WEAK = 0.55
+_AUTHOR_OK = 0.50
+
+STATUS_ICON = {
+    VERIFIED: "OK",
+    REVIEW: "REVIEW",
+    MISMATCH: "MISMATCH",
+    NOT_FOUND: "UNRESOLVED",
+    UNVERIFIED: "UNVERIFIED",
+    ERROR: "ERROR",
+}
+
+
+@dataclass
+class VerificationResult:
+    """The outcome of verifying one BibTeX entry."""
+
+    key: str
+    title: str
+    status: str
+    reason: str
+    confidence: float = 0.0
+    doi: str = ""
+    checked_via: str = ""
+    matched_title: str = ""
+    matched_doi: str = ""
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def authentic(self) -> bool:
+        return self.status == VERIFIED
+
+    @property
+    def needs_attention(self) -> bool:
+        """Anything that is not a clean ``verified`` is worth surfacing."""
+        return self.status != VERIFIED
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "status": self.status,
+            "reason": self.reason,
+            "confidence": round(self.confidence, 3),
+            "doi": self.doi,
+            "checkedVia": self.checked_via,
+            "matchedTitle": self.matched_title,
+            "matchedDoi": self.matched_doi,
+            "issues": self.issues,
+        }
+
+
+def verify_entry(entry: BibEntry, *, timeout: int = 20) -> VerificationResult:
+    """Verify a single BibTeX entry against authoritative databases."""
+    result = VerificationResult(
+        key=entry.key or "(no key)",
+        title=entry.title,
+        status=UNVERIFIED,
+        reason="",
+        doi=entry.doi,
+    )
+    try:
+        if entry.doi:
+            _verify_by_doi(entry, result, timeout)
+        elif entry.arxiv_id:
+            _verify_by_arxiv(entry, result, timeout)
+        else:
+            _verify_by_title(entry, result, timeout)
+    except SourceError as exc:
+        result.status = UNVERIFIED
+        result.checked_via = "network"
+        result.reason = f"Could not verify - {exc}. Try again later."
+    except Exception as exc:  # noqa: BLE001 - last-resort guard, surfaced to user
+        result.status = ERROR
+        result.reason = f"Verification error: {exc}"
+    return result
+
+
+def verify_entries(
+    entries: list[BibEntry],
+    *,
+    timeout: int = 20,
+    max_workers: int = 4,
+    progress: Callable[[int, int], None] | None = None,
+) -> list[VerificationResult]:
+    """Verify many entries concurrently, preserving input order.
+
+    ``progress`` is called with ``(completed, total)`` after each entry.
+    Concurrency is capped low to stay polite to the public APIs.
+    """
+    total = len(entries)
+    results: list[VerificationResult | None] = [None] * total
+    done = 0
+
+    def task(idx_entry):
+        idx, entry = idx_entry
+        return idx, verify_entry(entry, timeout=timeout)
+
+    with ThreadPoolExecutor(max_workers=max(1, min(max_workers, 8))) as pool:
+        for idx, res in pool.map(task, enumerate(entries)):
+            results[idx] = res
+            done += 1
+            if progress:
+                progress(done, total)
+
+    return [r for r in results if r is not None]
+
+
+def verify_bibtex(text: str, *, timeout: int = 20, **kwargs) -> list[VerificationResult]:
+    """Convenience wrapper: parse raw ``.bib`` text and verify every entry."""
+    return verify_entries(parse_bibtex(text), timeout=timeout, **kwargs)
+
+
+def summary(results: list[VerificationResult]) -> dict[str, int]:
+    """Count results by status, plus a ``total``."""
+    counts = {s: 0 for s in (VERIFIED, REVIEW, MISMATCH, NOT_FOUND, UNVERIFIED, ERROR)}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    counts["total"] = len(results)
+    return counts
+
+
+# --------------------------------------------------------------------------
+# Per-strategy verification
+# --------------------------------------------------------------------------
+
+def _verify_by_doi(entry, result, timeout):
+    """Verify an entry that carries a DOI."""
+    result.checked_via = "crossref/doi"
+    record = crossref_by_doi(entry.doi, timeout=timeout)
+    if record is not None:
+        _score_against_record(entry, result, record, identifier="DOI")
+        return
+
+    # CrossRef has no such work - consult the registry-agnostic Handle System
+    # before concluding anything, since books and datasets are not in CrossRef.
+    result.checked_via = "doi.org"
+    exists = doi_exists(entry.doi, timeout=timeout)
+    if exists is True:
+        result.status = VERIFIED
+        result.confidence = 0.6
+        result.reason = (
+            f"The DOI '{entry.doi}' is registered with the DOI system but is "
+            "not indexed by CrossRef, so its title could not be cross-checked."
+        )
+    elif exists is False:
+        result.status = NOT_FOUND
+        result.confidence = 0.9
+        result.reason = (
+            f"The DOI '{entry.doi}' does not resolve in CrossRef or the DOI "
+            "registry. Check that it is correct."
+        )
+    else:
+        result.status = UNVERIFIED
+        result.reason = (
+            f"The DOI '{entry.doi}' is not in CrossRef and the DOI registry "
+            "could not be reached to confirm it. Try again later."
+        )
+
+
+def _verify_by_arxiv(entry, result, timeout):
+    """Verify an entry that carries an arXiv identifier."""
+    result.checked_via = "arxiv"
+    record = arxiv_lookup(entry.arxiv_id, timeout=timeout)
+    if record is None:
+        result.status = NOT_FOUND
+        result.confidence = 0.9
+        result.reason = (
+            f"The arXiv ID '{entry.arxiv_id}' does not resolve to a paper on "
+            "arXiv. Check that it is correct."
+        )
+        return
+    _score_against_record(entry, result, record, identifier="arXiv ID")
+
+
+def _verify_by_title(entry, result, timeout):
+    """Verify an entry that has no DOI or arXiv ID - search CrossRef by title."""
+    result.checked_via = "crossref/search"
+    if not entry.title:
+        result.status = UNVERIFIED
+        result.reason = (
+            "The entry has no DOI, arXiv ID, or title, so there is nothing to "
+            "verify it against."
+        )
+        return
+
+    first_author = entry.authors[0] if entry.authors else None
+    records = crossref_search(entry.title, first_author, timeout=timeout)
+    if not records:
+        result.status = UNVERIFIED
+        result.reason = (
+            "This entry has no DOI, and no matching record was found in "
+            "CrossRef. Add a DOI so it can be verified."
+        )
+        return
+
+    best = max(records, key=lambda r: similarity(entry.title, r.title))
+    title_score = similarity(entry.title, best.title)
+    author_score = author_overlap(entry.authors, best.authors)
+    result.matched_title = best.title
+    result.matched_doi = best.doi
+    result.confidence = title_score
+
+    corroborated = author_score > 0 or _years_close(entry.year, best.year)
+    if title_score >= _TITLE_STRONG and corroborated:
+        result.status = VERIFIED
+        result.reason = (
+            f"A matching publication was found in CrossRef (DOI {best.doi}). "
+            f"Add 'doi = {{{best.doi}}}' to the entry to make it directly "
+            "verifiable."
+        )
+        result.issues = _metadata_issues(entry, best)
+    elif title_score >= _TITLE_STRONG:
+        result.status = REVIEW
+        result.reason = (
+            f"A publication with a very similar title was found in CrossRef "
+            f"(DOI {best.doi}), but its authors and year could not be matched "
+            "to this entry. Confirm it is the same work."
+        )
+    else:
+        result.status = UNVERIFIED
+        result.reason = (
+            "This entry has no DOI, and no confident match was found in "
+            f"CrossRef (closest: \"{best.title}\"). Add a DOI so it can be "
+            "verified."
+        )
+
+
+def _score_against_record(entry, result, record: Record, *, identifier: str):
+    """Compare an entry against the record its DOI/arXiv identifier resolved to."""
+    result.matched_title = record.title
+    result.matched_doi = record.doi or entry.doi
+    result.issues = _metadata_issues(entry, record)
+
+    if not entry.title:
+        result.status = VERIFIED
+        result.confidence = 0.7
+        result.reason = (
+            f"The {identifier} resolves to a registered {record.source} "
+            "record; the entry has no title to cross-check."
+        )
+        return
+
+    title_score = similarity(entry.title, record.title)
+    author_score = author_overlap(entry.authors, record.authors)
+    result.confidence = title_score
+
+    if title_score >= _TITLE_STRONG:
+        result.status = VERIFIED
+        result.reason = (
+            f"The {identifier} resolves and the title matches the "
+            f"{record.source} record."
+        )
+    elif author_score >= _AUTHOR_OK:
+        # Title differs but the authors agree - same paper, different encoding.
+        result.status = VERIFIED
+        result.confidence = max(title_score, author_score)
+        result.reason = (
+            f"The {identifier} resolves and the authors match the "
+            f"{record.source} record."
+        )
+        result.issues = result.issues + [
+            f"The registered title (\"{record.title}\") is written "
+            "differently from the entry - likely a formatting or source "
+            "difference."
+        ]
+    elif (
+        title_score < _TITLE_WEAK
+        and entry.authors
+        and record.authors
+        and author_score == 0
+    ):
+        # Two independent signals disagree - the identifier likely belongs
+        # to a different paper.
+        result.status = MISMATCH
+        result.reason = (
+            f"The {identifier} resolves, but to a record with a different "
+            f"title (\"{record.title}\") and different authors. The "
+            f"{identifier} may belong to another paper - check it."
+        )
+    else:
+        result.status = REVIEW
+        result.reason = (
+            f"The {identifier} resolves, but the registered title "
+            f"(\"{record.title}\") could not be matched to this entry with "
+            "confidence. Worth a quick check."
+        )
+
+
+def _metadata_issues(entry, record: Record) -> list[str]:
+    """Collect secondary metadata discrepancies (year, authors)."""
+    issues: list[str] = []
+    if entry.year and record.year and not _years_close(entry.year, record.year):
+        issues.append(
+            f"Year differs: the entry says {entry.year}, the record says "
+            f"{record.year}."
+        )
+    if entry.authors and record.authors:
+        if author_overlap(entry.authors, record.authors) < 0.34:
+            issues.append("Authors do not match the registered record.")
+    return issues
+
+
+def _years_close(a: str, b: str) -> bool:
+    """True when two year strings are within one year of each other."""
+    try:
+        return abs(int(a) - int(b)) <= 1
+    except (TypeError, ValueError):
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "doi2bib3"
-version = "1.1.1"
-description = "Fetch BibTeX from DOI, arXiv ID, journal URL and article title"
+version = "1.2.0"
+description = "Fetch BibTeX from DOI, arXiv ID, journal URL and article title, and verify references against CrossRef/arXiv"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "GPL-3.0-only"
 license-files = ["LICENSE"]
@@ -53,6 +53,9 @@ dev = [
 
 [tool.setuptools.packages.find]
 include = ["doi2bib3*"]
+
+[project.scripts]
+doi2bib3 = "doi2bib3.cli:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/scripts/doi2bib3
+++ b/scripts/doi2bib3
@@ -1,63 +1,23 @@
 #!/usr/bin/env python3
-"""Command-line interface script for doi2bib3.
+"""Legacy script entry point. Delegates to ``doi2bib3.cli:main``.
 
-When executed directly from the repository tree (e.g. ``python3 scripts/doi2bib3``),
-prefer the repository copy of the package over any system-installed one by
-inserting the repository root into ``sys.path`` before importing.
+The console script registered in ``pyproject.toml`` (``doi2bib3.cli:main``)
+is the canonical entry point for installed users; this file is kept so that
+``python scripts/doi2bib3 ...`` continues to work when running from a fresh
+checkout and so existing tests/packaging that point at it keep functioning.
 """
-import argparse
 import os
 import sys
 
-# Ensure local repo package is preferred when running the script from the
-# repository root (so testing modified code is straightforward).
 try:
-    # scripts/ is inside the repo; repo root is parent directory
+    # scripts/ lives inside the repo; the repo root is its parent.
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if repo_root not in sys.path:
         sys.path.insert(0, repo_root)
 except Exception:
     pass
 
-from doi2bib3.backend import fetch_bibtex
-from doi2bib3.io import save_bibtex_to_file
+from doi2bib3.cli import main
 
-
-def build_parser():
-    """Build the command-line parser."""
-    p = argparse.ArgumentParser(
-        description="Fetch BibTeX by DOI, DOI URL, arXiv id or arXiv URL"
-    )
-    p.add_argument(
-        "identifier",
-        nargs="?",
-        help="DOI, DOI URL, arXiv id/URL, or publisher URL",
-    )
-    p.add_argument("-o", "--out", help="Write .bib file to this path")
-    return p
-
-
-def main(argv=None):
-    """Run CLI: resolve identifier, fetch normalized BibTeX, output or save."""
-    parser = build_parser()
-    args = parser.parse_args(argv)
-    if not args.identifier:
-        parser.print_help()
-        return 2
-
-    try:
-        bib = fetch_bibtex(args.identifier)
-    except Exception as e:
-        print("Error:", e, file=sys.stderr)
-        return 1
-
-    if args.out:
-        save_bibtex_to_file(bib, args.out, append=True)
-        print("Wrote", args.out)
-    else:
-        print(bib)
-    return 0
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_verify_bibparser.py
+++ b/tests/test_verify_bibparser.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Pure-logic tests for the verify BibTeX parser (no network)."""
+
+import pytest
+
+from doi2bib3.verify.bibparser import BibEntry, normalize_doi, parse_bibtex
+
+
+SAMPLE = r"""
+@string{nat = "Nature"}
+
+@article{einstein1905,
+  author = {Einstein, Albert and Other, Author},
+  title  = {On the Electrodynamics of {Moving} Bodies},
+  year   = {1905},
+  doi    = {10.1002/andp.19053221004},
+  journal= nat
+}
+
+@misc{arxiv_demo,
+  title = {A preprint},
+  eprint = {2411.08091},
+  archiveprefix = {arXiv},
+  year = 2024,
+}
+
+@comment{a stray comment block}
+"""
+
+
+@pytest.mark.imported
+def test_parse_bibtex_returns_two_entries() -> None:
+    entries = parse_bibtex(SAMPLE)
+    assert [e.key for e in entries] == ["einstein1905", "arxiv_demo"]
+
+
+@pytest.mark.imported
+def test_string_substitution_works() -> None:
+    entry = parse_bibtex(SAMPLE)[0]
+    assert entry.get("journal") == "Nature"
+
+
+@pytest.mark.imported
+def test_authors_and_year_are_extracted() -> None:
+    entry = parse_bibtex(SAMPLE)[0]
+    assert entry.authors == ["Einstein, Albert", "Other, Author"]
+    assert entry.year == "1905"
+
+
+@pytest.mark.imported
+def test_doi_is_normalised() -> None:
+    entry = parse_bibtex(SAMPLE)[0]
+    assert entry.doi == "10.1002/andp.19053221004"
+
+
+@pytest.mark.imported
+def test_arxiv_id_detection_from_eprint() -> None:
+    entry = parse_bibtex(SAMPLE)[1]
+    assert entry.arxiv_id == "2411.08091"
+
+
+@pytest.mark.imported
+def test_normalize_doi_strips_prefixes_and_punctuation() -> None:
+    assert normalize_doi("https://doi.org/10.1038/nphys1170.") == "10.1038/nphys1170"
+    assert normalize_doi("DOI: 10.1038/Nphys1170") == "10.1038/nphys1170"
+    assert normalize_doi("") == ""
+
+
+@pytest.mark.imported
+def test_unknown_block_is_skipped_not_fatal() -> None:
+    text = "@string{not closed"  # malformed -- parser must not crash
+    assert parse_bibtex(text) == []

--- a/tests/test_verify_citecheck.py
+++ b/tests/test_verify_citecheck.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Pure-logic tests for the cite-key cross-checker (no network)."""
+
+import pytest
+
+from doi2bib3.verify.citecheck import check_cite_keys, extract_cite_keys
+
+
+@pytest.mark.imported
+def test_extract_cite_keys_handles_cite_family() -> None:
+    tex = r"""
+    See \cite{a} and \citep{b, c}. Also \autocite[p.~5]{d}, and
+    \citeauthor*{e}. Some prose, and finally \nocite{f}.
+    % A commented \cite{ignored} key.
+    """
+    assert extract_cite_keys(tex) == {"a", "b", "c", "d", "e", "f"}
+
+
+@pytest.mark.imported
+def test_check_cite_keys_reports_undefined_and_unused() -> None:
+    tex = [r"Body cites \cite{a, b} and \cite{ghost}."]
+    defined = {"a", "b", "unused_key"}
+    result = check_cite_keys(tex, defined)
+    assert result.undefined == {"ghost"}
+    assert result.unused == {"unused_key"}
+    assert result.cited == {"a", "b", "ghost"}
+
+
+@pytest.mark.imported
+def test_check_cite_keys_with_no_inputs() -> None:
+    result = check_cite_keys([], set())
+    assert result.cited == set()
+    assert result.defined == set()
+    assert result.undefined == set()
+    assert result.unused == set()
+
+
+@pytest.mark.imported
+def test_to_dict_returns_sorted_lists() -> None:
+    result = check_cite_keys([r"\cite{c, a, b, missing}"], {"a", "b", "c"})
+    payload = result.to_dict()
+    assert payload["undefined"] == ["missing"]
+    assert payload["unused"] == []
+    assert payload["citedCount"] == 4
+    assert payload["definedCount"] == 3

--- a/tests/test_verify_matching.py
+++ b/tests/test_verify_matching.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Pure-logic tests for the verify matching helpers (no network)."""
+
+import pytest
+
+from doi2bib3.verify.matching import (
+    author_overlap,
+    clean,
+    contained,
+    normalize,
+    similarity,
+    strip_markup,
+)
+
+
+@pytest.mark.imported
+def test_strip_markup_removes_xml_and_latex_and_entities() -> None:
+    raw = r"<mml:math><mml:mi>A</mml:mi></mml:math>{\bf B} &amp; C"
+    assert strip_markup(raw).replace(" ", "") == "AB&C"
+
+
+@pytest.mark.imported
+def test_normalize_lowercases_and_drops_punctuation() -> None:
+    assert normalize("On the {Origin} of Species!") == "on the origin of species"
+
+
+@pytest.mark.imported
+def test_similarity_is_one_for_identical_titles() -> None:
+    assert similarity("Foo Bar Baz", "Foo Bar Baz") == 1.0
+
+
+@pytest.mark.imported
+def test_similarity_is_high_for_subtitle_difference() -> None:
+    # CrossRef stores the main title only; the BibTeX entry includes the
+    # subtitle. The verifier should treat these as the same publication.
+    a = "Topology and Geometry for Physicists"
+    b = "Topology and Geometry for Physicists: a Modern Treatment"
+    assert similarity(a, b) >= 0.9
+
+
+@pytest.mark.imported
+def test_similarity_is_low_for_unrelated_titles() -> None:
+    assert similarity("Quantum entanglement primer", "Banana bread recipe") < 0.5
+
+
+@pytest.mark.imported
+def test_contained_requires_at_least_four_words() -> None:
+    assert contained("alpha beta gamma delta", "alpha beta gamma delta epsilon")
+    # Short fragments must not match -- they would cause spurious verdicts.
+    assert not contained("alpha beta", "alpha beta gamma delta")
+
+
+@pytest.mark.imported
+def test_clean_collapses_whitespace_and_strips_markup() -> None:
+    assert clean("  <jats:p>Hello,\nworld!</jats:p>  ") == "Hello, world!"
+
+
+@pytest.mark.imported
+def test_author_overlap_uses_surnames() -> None:
+    bib = ["Aspelmeyer, Markus", "Doe, Jane"]
+    record = ["Markus Aspelmeyer", "Other Person"]
+    # 1/2 of the record's authors have surnames present in the bib entry.
+    assert author_overlap(bib, record) == 0.5
+
+
+@pytest.mark.imported
+def test_author_overlap_handles_empty_inputs() -> None:
+    assert author_overlap([], ["A B"]) == 0.0
+    assert author_overlap(["A B"], []) == 0.0


### PR DESCRIPTION
New doi2bib3.verify subpackage and a 'doi2bib3 verify' CLI subcommand check BibTeX entries against CrossRef, arXiv and the DOI Handle System. The legacy bare-identifier form is preserved by routing unknown first args to 'fetch'.
